### PR TITLE
Generalized Trait

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /vendor/
+.idea
+composer.lock
+.phpunit*

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 Wes Roberts
+Copyright (c) 2018-2019 Wes Roberts, Librarian
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/composer.json
+++ b/composer.json
@@ -1,19 +1,25 @@
 {
-    "name": "jchook/phpunit-assert-throws",
-    "description": "Exception assertions for PHPUnit",
-    "type": "library",
-    "license": "MIT",
-    "authors": [
-        {
-            "name": "Wes Roberts",
-            "email": "u36g@a.zinc.email"
-        }
-    ],
-    "autoload": {
-        "psr-4": {
-            "Jchook\\AssertThrows\\": "src/"
-        }
+  "name": "jchook/phpunit-assert-throws",
+  "description": "Exception assertions for PHPUnit",
+  "type": "library",
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Wes Roberts",
+      "email": "u36g@a.zinc.email"
     },
-    "minimum-stability": "stable",
-    "require": {}
+    {
+      "name": "Librarian",
+      "email": "librarians.studios@gmail.com"
+    }
+  ],
+  "autoload": {
+    "psr-4": {
+      "Jchook\\AssertThrows\\": "src/"
+    }
+  },
+  "minimum-stability": "stable",
+  "require": {
+    "phpunit/phpunit": "^8.0.0"
+  }
 }

--- a/src/AssertThrows.php
+++ b/src/AssertThrows.php
@@ -1,50 +1,90 @@
-<?php
+<?php declare(strict_types = 1);
+
+/**
+ * MIT License
+ *
+ * Copyright (c) 2018-2019 Wes Roberts, Librarian
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 
 namespace Jchook\AssertThrows;
 
 use PHPUnit\Framework\Constraint\Exception as ConstraintException;
 use PHPUnit\Framework\Constraint\LogicalNot;
 use PHPUnit\Framework\ExpectationFailedException;
+use Throwable;
 
+/**
+ * Allows for multiple assertions checking for throwable without using multiple methods.
+ *
+ * @package Jchook\AssertThrows
+ * @author  Wes Roberts <u36g@a.zinc.email>
+ * @author  Librarian <librarians.studios@gmail.com>
+ * @since   1.0.0
+ */
 trait AssertThrows
 {
-	/**
-	 * @param string $class
-	 * @param callable $execute
-	 */
-	protected function assertNotThrows($class, callable $execute)
-	{
-		$exception = null;
-		try {
-			call_user_func($execute);
-		} catch (\Exception $e) {
-			$exception = $e;
-		}
-		if ($exception instanceof ExpectationFailedException) {
-			throw $exception;
-		}
-		self::assertThat($exception, new LogicalNot(new ConstraintException($class)));
-	}
+    /**
+     * Asserts that the callable doesn't throw a specified exception.
+     *
+     * @param string   $class The exception type expected not to be thrown.
+     * @param callable $execute The callable.
+     * @since   1.0.0
+     */
+    public function assertNotThrows(string $class, callable $execute) : void
+    {
+        try {
+            $execute();
+        } catch (ExpectationFailedException $e) {
+            throw $e;
+        } catch (Throwable $e) {
+            $this->assertThat($e, new LogicalNot(new ConstraintException($class)));
+        }
+    }
 
-	/**
-	 * @param string $class
-	 * @param callable $execute
-	 * @param callable|null $inspect optional
-	 */
-	protected function assertThrows($class, callable $execute, callable $inspect = null)
-	{
-		$exception = null;
-		try {
-			call_user_func($execute);
-		} catch (\Exception $e) {
-			$exception = $e;
-		}
-		if ($exception instanceof ExpectationFailedException) {
-			throw $exception;
-		}
-		self::assertThat($exception, new ConstraintException($class));
-		if ($inspect) {
-			call_user_func($inspect, $exception);
-		}
-	}
+    /**
+     * Asserts that the callable throws a specified throwable.
+     * If successful and the inspection callable is not null
+     * then it is called and the caught exception is passed as argument.
+     *
+     * @param string        $class The exception type expected to be thrown.
+     * @param callable      $execute The callable.
+     * @param callable|null $inspect [optional] The inspector.
+     * @since   1.0.0
+     */
+    public function assertThrows(string $class,
+                                 callable $execute,
+                                 callable $inspect = null) : void
+    {
+        try {
+            $execute();
+        } catch (ExpectationFailedException $e) {
+            throw $e;
+        } catch (Throwable $e) {
+            $this->assertThat($e, new ConstraintException($class));
+
+            if ($inspect !== null)
+                $inspect($e);
+
+            return;
+        }
+        $this->assertThat(null, new ConstraintException($class));
+    }
 }

--- a/tests/AssertThrowsTest.php
+++ b/tests/AssertThrowsTest.php
@@ -1,0 +1,87 @@
+<?php declare(strict_types = 1);
+
+use Jchook\AssertThrows\AssertThrows;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\TestCase;
+
+final class DummyAssert extends Assert
+{
+    use AssertThrows;
+}
+
+function throwError()
+{
+    throw new Error();
+}
+
+function throwException()
+{
+    throw new Exception();
+}
+
+function dontThrow()
+{
+}
+
+function inspectException(Exception $throwable)
+{
+    AbstractComparableTest::$inspected++;
+}
+
+function inspectError(Error $throwable)
+{
+    AbstractComparableTest::$inspected++;
+}
+
+final class AbstractComparableTest extends TestCase
+{
+    public static $inspected = 0;
+
+    protected function assertAssertionFails(callable $assertion, string $class, callable $execute)
+    {
+        try {
+            $assertion($class, $execute);
+        } catch (AssertionFailedError $e) {
+            return;
+        }
+        $this->fail("Assertion shouldn't have succeeded.");
+    }
+
+    protected function assertAssertionSucceeds(callable $assertion, string $class, callable $execute)
+    {
+        $assertion($class, $execute);
+    }
+
+    public final function testAssertNotThrows()
+    {
+        $this->assertAssertionFails([new DummyAssert(), "assertNotThrows"], Exception::class, "throwException");
+        $this->assertAssertionFails([new DummyAssert(), "assertNotThrows"], Error::class, "throwError");
+
+        $this->assertAssertionSucceeds([new DummyAssert(), "assertNotThrows"], Error::class, "throwException");
+        $this->assertAssertionSucceeds([new DummyAssert(), "assertNotThrows"], Exception::class, "throwError");
+
+        $this->assertAssertionSucceeds([new DummyAssert(), "assertNotThrows"], Exception::class, "dontThrow");
+        $this->assertAssertionSucceeds([new DummyAssert(), "assertNotThrows"], Error::class, "dontThrow");
+    }
+
+    public final function testAssertThrows()
+    {
+        $this->assertAssertionFails([new DummyAssert(), "assertThrows"], Error::class, "throwException");
+        $this->assertAssertionFails([new DummyAssert(), "assertThrows"], Exception::class, "throwError");
+
+        $this->assertAssertionFails([new DummyAssert(), "assertThrows"], Exception::class, "dontThrow");
+        $this->assertAssertionFails([new DummyAssert(), "assertThrows"], Error::class, "dontThrow");
+
+        $this->assertAssertionSucceeds([new DummyAssert(), "assertThrows"], Exception::class, "throwException");
+        $this->assertAssertionSucceeds([new DummyAssert(), "assertThrows"], Error::class, "throwError");
+    }
+
+    public final function testAssertThrowsInspector()
+    {
+        (new DummyAssert())->assertThrows(Exception::class, "throwException", "inspectException");
+        (new DummyAssert())->assertThrows(Exception::class, "throwException", "inspectException");
+    }
+}
+
+


### PR DESCRIPTION
Hi,

I wanted to be able to use assertThrows on PHPUnit and saw your repository as the most adapted one. However I wanted to use it on Errors and custom Throwables, so I updated it to handle this more general use case and added tests as well as documentation.

Added strict typing
Added PHPdoc comments
Added support for Throwable instead of just Exception
Added tests
Refactored functions
Updated licenses and composer.json