### PR TITLE
This test did not perform any assertions

### DIFF
--- a/src/AssertThrows.php
+++ b/src/AssertThrows.php
@@ -91,6 +91,7 @@ trait AssertThrows
 
             return;
         }
+		
         static::assertThat(null, new ConstraintException($class));
     }
 }

--- a/src/AssertThrows.php
+++ b/src/AssertThrows.php
@@ -55,8 +55,12 @@ trait AssertThrows
         } catch (ExpectationFailedException $e) {
             throw $e;
         } catch (Throwable $e) {
-            $this->assertThat($e, new LogicalNot(new ConstraintException($class)));
+            static::assertThat($e, new LogicalNot(new ConstraintException($class)));
+
+            return;
         }
+
+        static::assertThat(null, new LogicalNot(new ConstraintException($class)));
     }
 
     /**
@@ -79,7 +83,7 @@ trait AssertThrows
         } catch (ExpectationFailedException $e) {
             throw $e;
         } catch (Throwable $e) {
-            $this->assertThat($e, new ConstraintException($class));
+            static::assertThat($e, new ConstraintException($class));
 
             if ($inspect !== null) {
                 $inspect($e);
@@ -87,6 +91,6 @@ trait AssertThrows
 
             return;
         }
-        $this->assertThat(null, new ConstraintException($class));
+        static::assertThat(null, new ConstraintException($class));
     }
 }


### PR DESCRIPTION
A test which is only testing assertNotThrows and tests a method which does not throw an exception, results in "This test did not perform any assertions".